### PR TITLE
AmqpOut fix "Routing key" option

### DIFF
--- a/src/nodejs/amqp.ts
+++ b/src/nodejs/amqp.ts
@@ -95,7 +95,7 @@ module.exports = function(RED) {
     RED.nodes.createNode(node, n);
 
     node.source = n.source;
-    node.topic = n.topic;
+    node.topic = n.routingkey;
     node.ioType = n.iotype;
     node.ioName = n.ioname;
     node.server = RED.nodes.getNode(n.server);


### PR DESCRIPTION
Fix publishing messages with specified routing key in AmqpOut node definition option.