### PR TITLE
Fix for node connection error handling

### DIFF
--- a/lib/amqp.js
+++ b/lib/amqp.js
@@ -149,11 +149,9 @@ module.exports = function (RED) {
                     console.log(urlType + credentials + urlLocation);
                     opt.ca.push(new Buffer(node.ca, "base64"));
                 }
-                node.connection = new amqp.Connection(urlType + credentials + urlLocation, opt);
+                node.connection = new amqp.Connection(urlType + credentials + urlLocation, opt, {});
                 node.connectionPromise = node.connection.initialized.then(function () {
                     node.log("Connected to AMQP server " + urlType + urlLocation);
-                }).catch(function (e) {
-                    node.error("AMQP-SERVER error: " + e.message);
                 });
                 // Create topology
                 if (node.useTopology) {


### PR DESCRIPTION
This patch allows the 'catch' to be handled by the caller of 'claimConnection', so that the node status gets updated on a server connection error.